### PR TITLE
ZipArchiveAdapter::getMetadata() should check for directories.

### DIFF
--- a/src/ZipArchiveAdapter.php
+++ b/src/ZipArchiveAdapter.php
@@ -257,7 +257,7 @@ class ZipArchiveAdapter extends AbstractAdapter
         if (! $info = $this->archive->statName($location)) {
 
             // Check if $path is a directory.
-            if (substr($location, -1) !== '/' && !$info = $this->archive->statName($location . '/')) {
+            if (!$info = $this->archive->statName($location . '/')) {
                 return false;
             }
         }

--- a/src/ZipArchiveAdapter.php
+++ b/src/ZipArchiveAdapter.php
@@ -255,7 +255,11 @@ class ZipArchiveAdapter extends AbstractAdapter
         $location = $this->applyPathPrefix($path);
 
         if (! $info = $this->archive->statName($location)) {
-            return false;
+
+            // Check if $path is a directory.
+            if (substr($location, -1) !== '/' && !$info = $this->archive->statName($location . '/')) {
+                return false;
+            }
         }
 
         return $this->normalizeObject($info);

--- a/src/ZipArchiveAdapter.php
+++ b/src/ZipArchiveAdapter.php
@@ -256,8 +256,8 @@ class ZipArchiveAdapter extends AbstractAdapter
 
         if (! $info = $this->archive->statName($location)) {
 
-            // Check if $path is a directory.
-            if (!$info = $this->archive->statName($location . '/')) {
+            // Check if $location is a directory.
+            if (! $info = $this->archive->statName($location . '/')) {
                 return false;
             }
         }

--- a/tests/ZipArchiveTests.php
+++ b/tests/ZipArchiveTests.php
@@ -67,6 +67,10 @@ class ZipArchiveTests extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $zip->listContents());
         $zip->rename('file.txt', 'renamed.txt');
         $this->assertFalse($zip->has('file.txt'));
+
+        $zip->createDir('empty_dir', new Config());
+        $this->assertInternalType('array', $zip->getMetadata('empty_dir'));
+
         $stream = tmpfile();
         fwrite($stream, 'something');
         rewind($stream);


### PR DESCRIPTION
Zip archives are weird. In order to get the metadata for a directory, the path must end in a /. The fun part is that getMetadata() is normally used to determine the type of the file in the first place.

This is working for me.
